### PR TITLE
Relax setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ publish = [
 
 [build-system]
 requires = [
-    "setuptools~=67.6"
+    "setuptools>=67.6"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
The most recent version of setuptools is 68.1.2, which I'd like to build using. I've removed the upper limit in this PR, but I'd be open to just updating it too if there's a preference to keep using a minor version pin. (I didn't do that for now because it adds a burden on my work in [nixpkgs](https://hydra.nixos.org/jobset/nixpkgs/trunk); we currently have updated to 68.0.0, which is compatible with `~68.0` but we will try to update to 68.1.2 sometime, which is compatible with `~68.1`.)